### PR TITLE
add optional filter for MainWindowTitle to differenciate between multiple instances of the same process

### DIFF
--- a/OsuMemoryDataProvider/IOsuMemoryReader.cs
+++ b/OsuMemoryDataProvider/IOsuMemoryReader.cs
@@ -4,6 +4,8 @@ namespace OsuMemoryDataProvider
 {
     public interface IOsuMemoryReader
     {
+        IOsuMemoryReader GetInstanceForWindowTitleHint(string windowTitleHint);
+
         /// <summary>
         /// Fills all fields of PlayContainer with data read from osu! memory.
         /// </summary>

--- a/OsuMemoryDataProvider/OsuMemoryReader.cs
+++ b/OsuMemoryDataProvider/OsuMemoryReader.cs
@@ -1,6 +1,7 @@
 //#define MemoryTimes
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using ProcessMemoryDataFinder.API;
 
@@ -16,7 +17,15 @@ namespace OsuMemoryDataProvider
         /// </summary>
         public static IOsuMemoryReader Instance { get; } = new OsuMemoryReader();
 
-        public OsuMemoryReader() : base("osu!")
+        private static readonly ConcurrentDictionary<string, IOsuMemoryReader> Instances =
+            new ConcurrentDictionary<string, IOsuMemoryReader>();
+        public static IOsuMemoryReader GetInstanceForWindowTitleHint(string windowTitleHint)
+        {
+            if (string.IsNullOrEmpty(windowTitleHint)) return Instance;
+            return Instances.GetOrAdd(windowTitleHint, s => new OsuMemoryReader(s));
+        }
+
+        public OsuMemoryReader(string mainWindowTitleHint = null) : base("osu!", mainWindowTitleHint)
         {
             CreateSignatures();
         }

--- a/OsuMemoryDataProvider/OsuMemoryReader.cs
+++ b/OsuMemoryDataProvider/OsuMemoryReader.cs
@@ -19,7 +19,8 @@ namespace OsuMemoryDataProvider
 
         private static readonly ConcurrentDictionary<string, IOsuMemoryReader> Instances =
             new ConcurrentDictionary<string, IOsuMemoryReader>();
-        public static IOsuMemoryReader GetInstanceForWindowTitleHint(string windowTitleHint)
+
+        public IOsuMemoryReader GetInstanceForWindowTitleHint(string windowTitleHint)
         {
             if (string.IsNullOrEmpty(windowTitleHint)) return Instance;
             return Instances.GetOrAdd(windowTitleHint, s => new OsuMemoryReader(s));

--- a/OsuMemoryDataProviderTester/Form1.cs
+++ b/OsuMemoryDataProviderTester/Form1.cs
@@ -18,7 +18,7 @@ namespace OsuMemoryDataProviderTester
         {
             _osuWindowTitleHint = osuWindowTitleHint;
             InitializeComponent();
-            _reader = OsuMemoryReader.GetInstanceForWindowTitleHint(osuWindowTitleHint);
+            _reader = OsuMemoryReader.Instance.GetInstanceForWindowTitleHint(osuWindowTitleHint);
             Shown += OnShown;
             Closing += OnClosing;
             numericUpDown_readDelay.ValueChanged += NumericUpDownReadDelayOnValueChanged;

--- a/OsuMemoryDataProviderTester/Form1.cs
+++ b/OsuMemoryDataProviderTester/Form1.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Threading;
@@ -10,14 +9,16 @@ namespace OsuMemoryDataProviderTester
 {
     public partial class Form1 : Form
     {
+        private readonly string _osuWindowTitleHint;
         private int _readDelay = 33;
         private Thread _thread;
         private readonly IOsuMemoryReader _reader;
 
-        public Form1()
+        public Form1(string osuWindowTitleHint)
         {
+            _osuWindowTitleHint = osuWindowTitleHint;
             InitializeComponent();
-            _reader = OsuMemoryReader.Instance;
+            _reader = OsuMemoryReader.GetInstanceForWindowTitleHint(osuWindowTitleHint);
             Shown += OnShown;
             Closing += OnClosing;
             numericUpDown_readDelay.ValueChanged += NumericUpDownReadDelayOnValueChanged;
@@ -42,6 +43,7 @@ namespace OsuMemoryDataProviderTester
 
         private void OnShown(object sender, EventArgs eventArgs)
         {
+            if (!string.IsNullOrEmpty(_osuWindowTitleHint)) Text += $": {_osuWindowTitleHint}";
             _thread = new Thread(() =>
             {
                 try

--- a/OsuMemoryDataProviderTester/Form1.cs
+++ b/OsuMemoryDataProviderTester/Form1.cs
@@ -83,19 +83,24 @@ namespace OsuMemoryDataProviderTester
                             playContainer.Reset();
                         }
 
-                        BeginInvoke((MethodInvoker) (() =>
+                        int playTime = _reader.ReadPlayTime();
+                        int gameMode = _reader.ReadSongSelectGameMode();
+                        double displayedPlayerHp = _reader.ReadDisplayedPlayerHp();
+                        int mods = _reader.GetMods();
+
+                        Invoke((MethodInvoker) (() =>
                         {
                             textBox_mapId.Text = mapId.ToString();
                             textBox_strings.Text = mapStrings;
-                            textBox_time.Text = _reader.ReadPlayTime().ToString();
+                            textBox_time.Text = playTime.ToString();
                             textBox_mapData.Text = mapData;
-                            textBox_Status.Text = status + " " + num + " " + _reader.ReadSongSelectGameMode();
+                            textBox_Status.Text = status + " " + num + " " + gameMode;
 
                             textBox_CurrentPlayData.Text =
-                                playContainer + $" time:{_reader.ReadPlayTime()}" + Environment.NewLine +
+                                playContainer + $" time:{playTime}" + Environment.NewLine +
                                 $"hp________: {hp:00.##} {Environment.NewLine}" +
-                                $"displayedHp: {_reader.ReadDisplayedPlayerHp():00.##} {Environment.NewLine}" +
-                                $"mods:{_reader.GetMods()} " +
+                                $"displayedHp: {displayedPlayerHp:00.##} {Environment.NewLine}" +
+                                $"mods:{mods} " +
                                 $"PlayerName: {playerName}{Environment.NewLine}"+
                                 $"HitErrorCount: {hitErrorCount} ";
                         }));

--- a/OsuMemoryDataProviderTester/OsuMemoryDataProviderTester.csproj
+++ b/OsuMemoryDataProviderTester/OsuMemoryDataProviderTester.csproj
@@ -94,11 +94,18 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+    <None Include="tourney-client.bat">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OsuMemoryDataProvider\OsuMemoryDataProvider.csproj">
       <Project>{d117800f-072d-4ae4-9679-3e2a129a1a3c}</Project>
       <Name>OsuMemoryDataProvider</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ProcessMemoryDataFinder\ProcessMemoryDataFinder.csproj">
+      <Project>{9960D641-300A-432C-AA04-C351A99B9ADB}</Project>
+      <Name>ProcessMemoryDataFinder</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/OsuMemoryDataProviderTester/OsuMemoryDataProviderTester.csproj
+++ b/OsuMemoryDataProviderTester/OsuMemoryDataProviderTester.csproj
@@ -103,10 +103,6 @@
       <Project>{d117800f-072d-4ae4-9679-3e2a129a1a3c}</Project>
       <Name>OsuMemoryDataProvider</Name>
     </ProjectReference>
-    <ProjectReference Include="..\ProcessMemoryDataFinder\ProcessMemoryDataFinder.csproj">
-      <Project>{9960D641-300A-432C-AA04-C351A99B9ADB}</Project>
-      <Name>ProcessMemoryDataFinder</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/OsuMemoryDataProviderTester/Program.cs
+++ b/OsuMemoryDataProviderTester/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace OsuMemoryDataProviderTester
@@ -9,11 +10,11 @@ namespace OsuMemoryDataProviderTester
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
-        static void Main()
+        static void Main(string[] args)
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new Form1());
+            Application.Run(new Form1(args.FirstOrDefault()));
         }
     }
 }

--- a/OsuMemoryDataProviderTester/tourney-client.bat
+++ b/OsuMemoryDataProviderTester/tourney-client.bat
@@ -1,0 +1,6 @@
+﻿REM the manager window
+start OsuMemoryDataProviderTester.exe "Tournament Manager"
+
+REM all the individual client windows, repeat this line for however many clients there are
+start OsuMemoryDataProviderTester.exe "Tournament Client 0"
+start OsuMemoryDataProviderTester.exe "Tournament Client 1"

--- a/ProcessMemoryDataFinder/API/MemoryReader.cs
+++ b/ProcessMemoryDataFinder/API/MemoryReader.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using ProcessMemoryDataFinder.Misc;
 using Exception = System.Exception;
 
@@ -17,13 +18,15 @@ namespace ProcessMemoryDataFinder.API
         private readonly MemoryProcessAddressFinder _internals = new MemoryProcessAddressFinder();
 
         private readonly string _processName;
+        private readonly string _mainWindowTitleHint;
         private readonly ProcessMemoryReader _reader = new ProcessMemoryReader();
         private readonly SigScan _sigScan = new SigScan();
         private Process _currentProcess;
 
-        public MemoryReader(string processName)
+        protected MemoryReader(string processName, string mainWindowTitleHint)
         {
             _processName = processName;
+            _mainWindowTitleHint = mainWindowTitleHint;
         }
 
         protected virtual Process CurrentProcess
@@ -117,8 +120,12 @@ namespace ProcessMemoryDataFinder.API
                     return;
                 }
 
-                var p = Process.GetProcessesByName(_processName);
-                var resolvedProcess = p.Length == 0 ? null : p[0];
+                IEnumerable<Process> p = Process.GetProcessesByName(_processName);
+                if(!string.IsNullOrEmpty(_mainWindowTitleHint))
+                {
+                    p = p.Where(x => x.MainWindowTitle.IndexOf(_mainWindowTitleHint) >= 0);
+                }
+                var resolvedProcess = p.FirstOrDefault();
                 if (resolvedProcess != null || CurrentProcess != null)
                 {
                     CurrentProcess = resolvedProcess;

--- a/ProcessMemoryDataFinder/API/MemoryReaderEx.cs
+++ b/ProcessMemoryDataFinder/API/MemoryReaderEx.cs
@@ -7,7 +7,7 @@ namespace ProcessMemoryDataFinder.API
     {
         protected Dictionary<int, SigEx> Signatures = new Dictionary<int, SigEx>();
 
-        protected MemoryReaderEx(string processName) : base(processName)
+        protected MemoryReaderEx(string processName, string mainWindowTitleHint = null) : base(processName, mainWindowTitleHint)
         {
         }
 


### PR DESCRIPTION
basically instead of just giving it a process name, also optionally give it a string which if set it will filter the list of processes gotten from the process name by instances of that process that have that string in their MainWindowTitle.

This allows me to create specific OsuMemoryReader instances for each process used by the tourney client: the manager and each individual spectate client.

However for some reason reading the memory of the spectate clients seems to rather unstable and im not sure why, ive had multiple processes just straight up die on me with weird exceptions or even visual studio errors (see discord).

But ive also had moments it works perfectly amazing just like how I expected it to work. I have no idea what the difference is between those runs......