### PR TITLE
Fix: Make all IntPtr logic platform-aware & configure project build contexts

### DIFF
--- a/OsuMemoryDataProvider/OsuMemoryDataProvider.csproj
+++ b/OsuMemoryDataProvider/OsuMemoryDataProvider.csproj
@@ -1,4 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net472;net471</TargetFrameworks>
+    <Platforms>x86</Platforms>
+    <OutputType>Library</OutputType>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AssemblyTitle>OsuMemoryDataProvider</AssemblyTitle>
+    <Product>OsuMemoryDataProvider</Product>
+    <Copyright>2019-2020 Piotr Partyka</Copyright>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Authors>Piotrekol</Authors>
+    <PackageId>OsuMemoryDataProvider</PackageId>
+    <Description>Read osu! game memory values based on pre-made memory signatures(patterns)</Description>
+    <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/Piotrekol/ProcessMemoryDataFinder/tree/master/OsuMemoryDataProvider</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Piotrekol/ProcessMemoryDataFinder/tree/master/OsuMemoryDataProvider</RepositoryUrl>
+    <title>OsuMemoryDataProvider</title>
+    <Summary>Read osu! game memory values based on pre-made memory signatures(patterns)</Summary>
+    <Version>0.0.1</Version>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <OutputPath>bin\x86\Debug\</OutputPath>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
@@ -7,36 +31,11 @@
     <OutputPath>bin\x86\Release\</OutputPath>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net471</TargetFrameworks>
-    <OutputType>Library</OutputType>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-	  <AssemblyTitle>OsuMemoryDataProvider</AssemblyTitle>
-	  <Product>OsuMemoryDataProvider</Product>
-	  <Copyright>2019-2020 Piotr Partyka</Copyright>
-	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	  <Authors>Piotrekol</Authors>
-	  <PackageId>OsuMemoryDataProvider</PackageId>
-	  <Description>Read osu! game memory values based on pre-made memory signatures(patterns)</Description>
-	  <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
-	  <PackageProjectUrl>https://github.com/Piotrekol/ProcessMemoryDataFinder/tree/master/OsuMemoryDataProvider</PackageProjectUrl>
-	  <RepositoryUrl>https://github.com/Piotrekol/ProcessMemoryDataFinder/tree/master/OsuMemoryDataProvider</RepositoryUrl>
-	  <title>OsuMemoryDataProvider</title>
-	  <Summary>Read osu! game memory values based on pre-made memory signatures(patterns)</Summary>
-	  <Version>0.0.1</Version>
-	  <IncludeSymbols>true</IncludeSymbols>
-	  <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|x86'">
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <OutputPath>bin\x64\Debug\</OutputPath>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <OutputPath>bin\x64\Release\</OutputPath>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp3.1|x86'">
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ProcessMemoryDataFinder\ProcessMemoryDataFinder.csproj" />

--- a/OsuMemoryDataProviderTester/OsuMemoryDataProviderTester.csproj
+++ b/OsuMemoryDataProviderTester/OsuMemoryDataProviderTester.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net472;net471</TargetFrameworks>
+    <Platforms>x86</Platforms>
     <OutputType>WinExe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
@@ -13,13 +14,11 @@
     <OutputPath>bin\x86\Release\</OutputPath>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <OutputPath>bin\x64\Debug\</OutputPath>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|x86'">
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <OutputPath>bin\x64\Release\</OutputPath>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp3.1|x86'">
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <None Update="tourney-client.bat">

--- a/ProcessMemoryDataFinder.sln
+++ b/ProcessMemoryDataFinder.sln
@@ -3,11 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29009.5
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProcessMemoryDataFinder", "ProcessMemoryDataFinder\ProcessMemoryDataFinder.csproj", "{9960D641-300A-432C-AA04-C351A99B9ADB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProcessMemoryDataFinder", "ProcessMemoryDataFinder\ProcessMemoryDataFinder.csproj", "{9960D641-300A-432C-AA04-C351A99B9ADB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OsuMemoryDataProvider", "OsuMemoryDataProvider\OsuMemoryDataProvider.csproj", "{D117800F-072D-4AE4-9679-3E2A129A1A3C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OsuMemoryDataProvider", "OsuMemoryDataProvider\OsuMemoryDataProvider.csproj", "{D117800F-072D-4AE4-9679-3E2A129A1A3C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OsuMemoryDataProviderTester", "OsuMemoryDataProviderTester\OsuMemoryDataProviderTester.csproj", "{2450525D-627D-4ABA-ACF0-FA1AA76CE4A0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OsuMemoryDataProviderTester", "OsuMemoryDataProviderTester\OsuMemoryDataProviderTester.csproj", "{2450525D-627D-4ABA-ACF0-FA1AA76CE4A0}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "osu!", "osu!", "{FD3B44E6-66B3-4C58-B590-FB11B9CF6FF7}"
 EndProject
@@ -19,30 +19,26 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{9960D641-300A-432C-AA04-C351A99B9ADB}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{9960D641-300A-432C-AA04-C351A99B9ADB}.Debug|x64.Build.0 = Debug|Any CPU
-		{9960D641-300A-432C-AA04-C351A99B9ADB}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{9960D641-300A-432C-AA04-C351A99B9ADB}.Debug|x86.Build.0 = Debug|Any CPU
-		{9960D641-300A-432C-AA04-C351A99B9ADB}.Release|x64.ActiveCfg = Release|Any CPU
-		{9960D641-300A-432C-AA04-C351A99B9ADB}.Release|x64.Build.0 = Release|Any CPU
-		{9960D641-300A-432C-AA04-C351A99B9ADB}.Release|x86.ActiveCfg = Release|Any CPU
-		{9960D641-300A-432C-AA04-C351A99B9ADB}.Release|x86.Build.0 = Release|Any CPU
-		{D117800F-072D-4AE4-9679-3E2A129A1A3C}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{D117800F-072D-4AE4-9679-3E2A129A1A3C}.Debug|x64.Build.0 = Debug|Any CPU
-		{D117800F-072D-4AE4-9679-3E2A129A1A3C}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{D117800F-072D-4AE4-9679-3E2A129A1A3C}.Debug|x86.Build.0 = Debug|Any CPU
-		{D117800F-072D-4AE4-9679-3E2A129A1A3C}.Release|x64.ActiveCfg = Release|Any CPU
-		{D117800F-072D-4AE4-9679-3E2A129A1A3C}.Release|x64.Build.0 = Release|Any CPU
-		{D117800F-072D-4AE4-9679-3E2A129A1A3C}.Release|x86.ActiveCfg = Release|Any CPU
-		{D117800F-072D-4AE4-9679-3E2A129A1A3C}.Release|x86.Build.0 = Release|Any CPU
-		{2450525D-627D-4ABA-ACF0-FA1AA76CE4A0}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{2450525D-627D-4ABA-ACF0-FA1AA76CE4A0}.Debug|x64.Build.0 = Debug|Any CPU
-		{2450525D-627D-4ABA-ACF0-FA1AA76CE4A0}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{2450525D-627D-4ABA-ACF0-FA1AA76CE4A0}.Debug|x86.Build.0 = Debug|Any CPU
-		{2450525D-627D-4ABA-ACF0-FA1AA76CE4A0}.Release|x64.ActiveCfg = Release|Any CPU
-		{2450525D-627D-4ABA-ACF0-FA1AA76CE4A0}.Release|x64.Build.0 = Release|Any CPU
-		{2450525D-627D-4ABA-ACF0-FA1AA76CE4A0}.Release|x86.ActiveCfg = Release|Any CPU
-		{2450525D-627D-4ABA-ACF0-FA1AA76CE4A0}.Release|x86.Build.0 = Release|Any CPU
+		{9960D641-300A-432C-AA04-C351A99B9ADB}.Debug|x64.ActiveCfg = Debug|x64
+		{9960D641-300A-432C-AA04-C351A99B9ADB}.Debug|x64.Build.0 = Debug|x64
+		{9960D641-300A-432C-AA04-C351A99B9ADB}.Debug|x86.ActiveCfg = Debug|x86
+		{9960D641-300A-432C-AA04-C351A99B9ADB}.Debug|x86.Build.0 = Debug|x86
+		{9960D641-300A-432C-AA04-C351A99B9ADB}.Release|x64.ActiveCfg = Release|x64
+		{9960D641-300A-432C-AA04-C351A99B9ADB}.Release|x64.Build.0 = Release|x64
+		{9960D641-300A-432C-AA04-C351A99B9ADB}.Release|x86.ActiveCfg = Release|x86
+		{9960D641-300A-432C-AA04-C351A99B9ADB}.Release|x86.Build.0 = Release|x86
+		{D117800F-072D-4AE4-9679-3E2A129A1A3C}.Debug|x64.ActiveCfg = Debug|x86
+		{D117800F-072D-4AE4-9679-3E2A129A1A3C}.Debug|x86.ActiveCfg = Debug|x86
+		{D117800F-072D-4AE4-9679-3E2A129A1A3C}.Debug|x86.Build.0 = Debug|x86
+		{D117800F-072D-4AE4-9679-3E2A129A1A3C}.Release|x64.ActiveCfg = Release|x86
+		{D117800F-072D-4AE4-9679-3E2A129A1A3C}.Release|x86.ActiveCfg = Release|x86
+		{D117800F-072D-4AE4-9679-3E2A129A1A3C}.Release|x86.Build.0 = Release|x86
+		{2450525D-627D-4ABA-ACF0-FA1AA76CE4A0}.Debug|x64.ActiveCfg = Debug|x86
+		{2450525D-627D-4ABA-ACF0-FA1AA76CE4A0}.Debug|x86.ActiveCfg = Debug|x86
+		{2450525D-627D-4ABA-ACF0-FA1AA76CE4A0}.Debug|x86.Build.0 = Debug|x86
+		{2450525D-627D-4ABA-ACF0-FA1AA76CE4A0}.Release|x64.ActiveCfg = Release|x86
+		{2450525D-627D-4ABA-ACF0-FA1AA76CE4A0}.Release|x86.ActiveCfg = Release|x86
+		{2450525D-627D-4ABA-ACF0-FA1AA76CE4A0}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ProcessMemoryDataFinder/API/MemoryReader.cs
+++ b/ProcessMemoryDataFinder/API/MemoryReader.cs
@@ -97,10 +97,9 @@ namespace ProcessMemoryDataFinder.API
                 return null;
             }
 
-            int bytesNumber;
             var bytesRead =
                 _reader.ReadProcessMemory(address, size,
-                    out bytesNumber);
+                    out var bytesNumber);
             if (bytesNumber == size)
             {
                 return bytesRead;

--- a/ProcessMemoryDataFinder/API/MemoryReaderEx.cs
+++ b/ProcessMemoryDataFinder/API/MemoryReaderEx.cs
@@ -111,6 +111,12 @@ namespace ProcessMemoryDataFinder.API
             return sig.GetIntList();
         }
 
+        protected virtual int[] GetIntArray(int signatureId)
+        {
+            var sig = InitSignature(signatureId);
+            return sig.GetIntArray();
+        }
+
         #endregion
     }
 }

--- a/ProcessMemoryDataFinder/API/Sig.cs
+++ b/ProcessMemoryDataFinder/API/Sig.cs
@@ -136,9 +136,15 @@ namespace ProcessMemoryDataFinder.API
 
         private IntPtr ReadPointer(IntPtr baseAddr)
         {
+#if x64
+            var data = _readDataFunc(baseAddr, 8);
+            if (data != null)
+                return new IntPtr(BitConverter.ToInt64(data, 0));
+#else
             var data = _readDataFunc(baseAddr, 4);
             if (data != null)
                 return new IntPtr(BitConverter.ToInt32(data, 0));
+#endif
             return IntPtr.Zero;
         }
 

--- a/ProcessMemoryDataFinder/API/Sig.cs
+++ b/ProcessMemoryDataFinder/API/Sig.cs
@@ -185,103 +185,147 @@ namespace ProcessMemoryDataFinder.API
             return -1;
         }
 
-        private Tuple<int, IntPtr> GetArrayHeader(bool skip = false)
+        /// <summary>
+        /// Get the number of elements and a pointer to the first element of an array like structure, supported structures at the moment are: a simple array, a List object, and a string.
+        ///
+        /// An string and a simple array are very similar but every so slightly different (the size of the number of elements fields)
+        /// A List object has its own number of elements field and an internal array containing the elements itself
+        /// </summary>
+        /// <param name="isList"></param>
+        /// <param name="isString"></param>
+        /// <returns></returns>
+        private (int numberOfElements, IntPtr firstElementPtr) GetArrayLikeHeader(bool isList, bool isString)
         {
             var pointer = ResolveAddress();
-            if (pointer == IntPtr.Zero) return null;
+            if (pointer == IntPtr.Zero) return (-1, IntPtr.Zero);
 
             var address = ReadPointer(pointer);
-            if (address == IntPtr.Zero) return null;
+            if (address == IntPtr.Zero) return (-1, IntPtr.Zero);
 
-            IntPtr arrayAddress;
-            if (skip)
+            int numberOfElements;
+            IntPtr firstElementPtr;
+
+            if (isList)
             {
-                arrayAddress = address;
+                // its a list, not an array, read the length from the list object and get the firstElementPtr from the internal array
+#if x64
+                var numberOfElementsAddr = address + 0x18;
+#else
+                var numberOfElementsAddr = address + 0x0C;
+#endif
+                // in a list, regardless of platform, the size element is always 4 bytes
+                var numberOfElementBytes = _readDataFunc(numberOfElementsAddr, 4);
+                numberOfElements = BitConverter.ToInt32(numberOfElementBytes, 0);
+
+                // lets point to the first element in the internal array:
+                // 1. skip VTable of list structure (4 or 8 bytes depending on platform)
+                // 2. resolve pinter to internal array
+                // 3. skip VTable and internal number of elements (both 4 or 8 bytes depending on platform)
+#if x64
+                var internalArray = ReadPointer(address + 8);
+                firstElementPtr = internalArray + 16;
+#else
+                var internalArray = ReadPointer(address + 4);
+                firstElementPtr = internalArray + 8;
+#endif
             }
             else
             {
+                // normal array, first element in the structure is the length, skip VTable
 #if x64
-                arrayAddress = ReadPointer(address + 8);
+                var numberOfElementsAddr = address + 8;
 #else
-                arrayAddress = ReadPointer(address + 4);
+                var numberOfElementsAddr = address + 4;
 #endif
-                if (arrayAddress == IntPtr.Zero) return null;
+                // in an array structure the size of of the numberOfElements field depends on the platform (4 bytes or 8 bytes)
+                // except for a string, then its always 4 bytes
+                // first element in the array is after the numberOfElements field
+#if x64
+                // 64bit platform, unless string size bytes is 8
+                if (isString)
+                {
+                    var numberOfElementBytes = _readDataFunc(numberOfElementsAddr, 4);
+                    numberOfElements = BitConverter.ToInt32(numberOfElementBytes, 0);
+                    firstElementPtr = numberOfElementsAddr + 4;
+                }
+                else
+                {
+                    var numberOfElementBytes = _readDataFunc(numberOfElementsAddr, 8);
+                    var numberOfElementsLong = BitConverter.ToInt64(numberOfElementBytes, 0);
+                    // ok, realistically we're probably never gonna get an array of more then 2^32-1 elements, so lets cast this down to an int
+                    if (numberOfElementsLong > int.MaxValue)
+                    {
+                        // unable to read, lets just return nothing
+                        return (-1, IntPtr.Zero);
+                    }
+                    numberOfElements = (int) numberOfElementsLong;
+                    firstElementPtr = numberOfElementsAddr + 8;
+                }
+#else
+                // 32bit platform, its always 4 bytes, regardless of the value of isString
+                var numberOfElementBytes = _readDataFunc(numberOfElementsAddr, 4);
+                numberOfElements = BitConverter.ToInt32(numberOfElementBytes, 0);
+                firstElementPtr = numberOfElementsAddr + 4;
+#endif
             }
 
-            byte[] rawNumberOfElements;
-            if (skip)
-            {
-#if x64
-                rawNumberOfElements = _readDataFunc(arrayAddress + 8, 4); //Amount of allocated space (char[] (strings))
-#else
-                rawNumberOfElements = _readDataFunc(arrayAddress + 4, 4); //Amount of allocated space (char[] (strings))
-#endif
-            }
-            else
-            {
-#if x64
-                rawNumberOfElements = _readDataFunc(address + 24, 4); //Array.Count()
-#else
-                rawNumberOfElements = _readDataFunc(address + 12, 4); //Array.Count()
-#endif
-            }
-
-            if (rawNumberOfElements == null) return null;
-            var numberOfElements = BitConverter.ToInt32(rawNumberOfElements, 0);
-
-            return Tuple.Create(numberOfElements, arrayAddress);
+            return (numberOfElements, firstElementPtr);
         }
 
         public List<int> GetIntList()
         {
-            var headerResult = GetArrayHeader();
-            if (headerResult == null) return null;
-            if (headerResult.Item1 <= 0) return new List<int>();
+             var (numberOfElements, firstElementPtr) = GetArrayLikeHeader(true, false);
+             if (numberOfElements < 0) return null;
+             if (numberOfElements == 0) return new List<int>();
 
-            var ret = new List<int>();
-            var expectedSize = 4 * (uint) headerResult.Item1;
+             var totalByteCount = 4 * numberOfElements;
+             var bytes = _readDataFunc(firstElementPtr, (uint)totalByteCount);
+             if (bytes == null || bytes.Length != totalByteCount) return null;
 
-#if x64
-            var memoryFragment = _readDataFunc(headerResult.Item2 + 16, expectedSize);
-#else
-            var memoryFragment = _readDataFunc(headerResult.Item2 + 8, expectedSize);
-#endif
+             var list = new List<int>(numberOfElements);
+             for (var offset = 0; offset < totalByteCount; offset += 4)
+             {
+                 list.Add(BitConverter.ToInt32(bytes, offset));
+             }
 
-            if (memoryFragment == null || memoryFragment.Length != expectedSize)
-                return null;
+             return list;
+        }
 
-            for (int i = 0; i < headerResult.Item1; i++)
+        public int[] GetIntArray()
+        {
+            var (numberOfElements, firstElementPtr) = GetArrayLikeHeader(false, false);
+            if (numberOfElements < 0) return null;
+            if (numberOfElements == 0) return Array.Empty<int>();
+
+            var totalByteCount = 4 * numberOfElements;
+            var bytes = _readDataFunc(firstElementPtr, (uint)totalByteCount);
+            if (bytes == null || bytes.Length != totalByteCount) return null;
+
+            var arr = new int[numberOfElements];
+            for (int offset = 0, i = 0; i < numberOfElements; offset += 4, ++i)
             {
-                ret.Add(BitConverter.ToInt32(memoryFragment, i * 4));
+                arr[i] = BitConverter.ToInt32(bytes, offset);
             }
 
-            return ret;
+            return arr;
         }
+
         public string GetString()
         {
+             var (numberOfElements, firstElementPtr) = GetArrayLikeHeader(false, true);
+             if (numberOfElements <= 0) return string.Empty;
+             
+             /*
+              * If there's a case where string can be longer than 2^18, this should get adjusted to bigger value.
+              * In my testing in StreamCompanion(across whole userbase) this value can be [incorrectly] set to ridiculous value, sometimes even causing OutOfMemoryException
+              */
+             if (numberOfElements > 262144) return string.Empty;
 
-            var headerResult = GetArrayHeader(true);
-            if (headerResult == null) return string.Empty;
-            if (headerResult.Item1 == 0) return string.Empty;
+             var totalByteCount = 2 * numberOfElements;
+             var bytes = _readDataFunc(firstElementPtr, (uint) totalByteCount);
+             if (bytes == null || bytes.Length != totalByteCount) return null;
 
-            var stringLength = headerResult.Item1 * 2;
-            /*
-             * If there's a case where string can be longer than 2^18, this should get adjusted to bigger value.
-             * In my testing in StreamCompanion(across whole userbase) this value can be [incorrectly] set to ridiculous value, sometimes even causing OutOfMemoryException
-             */
-            if (stringLength > 262144) return string.Empty;
-
-            if (stringLength == 0) return string.Empty;
-
-#if x64
-            var stringData = _readDataFunc(headerResult.Item2 + 12, (uint)stringLength);
-#else
-            var stringData = _readDataFunc(headerResult.Item2 + 8, (uint)stringLength);
-#endif
-            if (stringData == null) return string.Empty;
-
-            var result = Encoding.Unicode.GetString(stringData);
-            return result;
+             return Encoding.Unicode.GetString(bytes);
         }
 
         public override string ToString()

--- a/ProcessMemoryDataFinder/API/SigScan.cs
+++ b/ProcessMemoryDataFinder/API/SigScan.cs
@@ -224,7 +224,7 @@ namespace ProcessMemoryDataFinder.API
                     if (MaskCheck(x, btPattern, strMask))
                     {
                         // The pattern was found, return it.
-                        return new IntPtr((int)m_vAddress + (x + nOffset));
+                        return m_vAddress + (x + nOffset);
                     }
                 }
 
@@ -329,21 +329,21 @@ namespace ProcessMemoryDataFinder.API
                 if (!DumpMemory())
                     return IntPtr.Zero;
             }
-            var result = Scan(this.m_vDumpedRegion, patternBytes);
-            if (result != IntPtr.Zero)
-                return result + (int)m_vAddress+ nOffset;
-             return result;
-            
+            var result = Scan(m_vDumpedRegion, patternBytes);
+            if (result == -1)
+                return IntPtr.Zero;
+
+            return m_vAddress + (nOffset + result);
         }
 
-        private IntPtr Scan(byte[] sIn, byte[] sFor)
+        private static int Scan(byte[] sIn, byte[] sFor)
         {
             if (sIn == null)
             {
-                return IntPtr.Zero;
+                return -1;
             }
 
-            int[] sBytes = new int[256]; int pool = 0;
+            int[] sBytes = new int[256];
             int end = sFor.Length - 1;
             for (int i = 0; i < 256; i++)
             {
@@ -355,19 +355,20 @@ namespace ProcessMemoryDataFinder.API
                 sBytes[sFor[i]] = end - i;
             }
 
+            int pool = 0;
             while (pool <= sIn.Length - sFor.Length)
             {
                 for (int i = end; (sIn[pool + i] == sFor[i]); i--)
                 {
                     if (i == 0)
                     {
-                        return new IntPtr(pool);
+                        return pool;
                     }
                 }
 
                 pool += sBytes[sIn[pool + end]];
             }
-            return IntPtr.Zero;
+            return -1;
         }
     }
 

--- a/ProcessMemoryDataFinder/ProcessMemoryDataFinder.csproj
+++ b/ProcessMemoryDataFinder/ProcessMemoryDataFinder.csproj
@@ -1,29 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <OutputPath>bin\x86\Debug\</OutputPath>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <OutputPath>bin\x86\Release\</OutputPath>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
   <PropertyGroup>
-	  <TargetFrameworks>netcoreapp3.1;net472;net471</TargetFrameworks>
-	  <AssemblyTitle>ProcessMemoryDataFinder</AssemblyTitle>
-	  <Product>ProcessMemoryDataFinder</Product>
-	  <Copyright>2019-2020 Piotr Partyka</Copyright>
-	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	  <Authors>Piotrekol</Authors>
-	  <PackageId>ProcessMemoryDataFinder</PackageId>
-	  <Description>Find and read data in processes based on pre-made memory signatures(patterns)</Description>
-	  <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
-	  <PackageProjectUrl>https://github.com/Piotrekol/ProcessMemoryDataFinder/tree/master/ProcessMemoryDataFinder</PackageProjectUrl>
-	  <RepositoryUrl>https://github.com/Piotrekol/ProcessMemoryDataFinder/tree/master/ProcessMemoryDataFinder</RepositoryUrl>
-	  <title>ProcessMemoryDataFinder</title>
-	  <Summary>Find and read data in processes based on pre-made memory signatures(patterns)</Summary>
-	  <Version>0.0.1</Version>
-	  <IncludeSymbols>true</IncludeSymbols> 
-	  <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <TargetFrameworks>netcoreapp3.1;net472;net471</TargetFrameworks>
+    <Platforms>x64;x86</Platforms>
+    <AssemblyTitle>ProcessMemoryDataFinder</AssemblyTitle>
+    <Product>ProcessMemoryDataFinder</Product>
+    <Copyright>2019-2020 Piotr Partyka</Copyright>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Authors>Piotrekol</Authors>
+    <PackageId>ProcessMemoryDataFinder</PackageId>
+    <Description>Find and read data in processes based on pre-made memory signatures(patterns)</Description>
+    <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/Piotrekol/ProcessMemoryDataFinder/tree/master/ProcessMemoryDataFinder</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Piotrekol/ProcessMemoryDataFinder/tree/master/ProcessMemoryDataFinder</RepositoryUrl>
+    <title>ProcessMemoryDataFinder</title>
+    <Summary>Find and read data in processes based on pre-made memory signatures(patterns)</Summary>
+    <Version>0.0.1</Version>
+    <IncludeSymbols>true</IncludeSymbols> 
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />
@@ -39,6 +32,26 @@
     <OutputPath>bin\x64\Release\</OutputPath>
     <DefineConstants>TRACE;x64</DefineConstants>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|x64'">
+    <DefineConstants>DEBUG;TRACE;x64</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp3.1|x64'">
+    <DefineConstants>TRACE;x64</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|x86'">
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp3.1|x86'">
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />


### PR DESCRIPTION
some additional details:
- the 2 osu related projects wont build in x64, ive disabled those builds (if you try you get platform mismatch errors), since they likely wont work anyway. The ProcessMemoryDataFinder lib project can be build for both x64 and x86
- in all 3 csproj files there are <PropertyGroup> blocks with conditions, first a bunch that dont specify the TargetFramework and then a bunch that do. The only reason those last ones are there is that otherwise VisualStudio aparently doesnt understand the settings set in the ones above it, so the DEBUG symbol is not set for debug configurations and the x64 symbol is not set for x64 configurations. It is kinda ugly but I dont know of any other way. Seems like a VisualStudio bug to me or something, but it doesnt understand the multiple target frameworks or whatever, no idea /shrug